### PR TITLE
Added ability to work with --fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,10 +128,16 @@ module.exports = {
 							call: {
 								type: "boolean",
 							},
+							func: {
+								type: "boolean",
+							},
 							object: {
 								type: "boolean",
 							},
 							simple: {
+								type: "boolean",
+							},
+							addParensOnSameLine: {
 								type: "boolean",
 							},
 						},
@@ -149,6 +155,7 @@ module.exports = {
 				var comparisonMode = defaultsOnly || !("comparison" in extraOptions) || extraOptions.comparison === true;
 				var logicalMode = defaultsOnly || !("logical" in extraOptions) || extraOptions.logical === true;
 				var callMode = defaultsOnly || !("call" in extraOptions) || extraOptions.call === true;
+				var funcMode = defaultsOnly || !("func" in extraOptions) || extraOptions.func === false;
 				var objectMode = defaultsOnly || !("object" in extraOptions) || extraOptions.object === true;
 				var simpleMode = (!defaultsOnly && extraOptions && extraOptions.simple === true);
 
@@ -163,6 +170,7 @@ module.exports = {
 								(clause.type == "LogicalExpression") ? "logical" :
 								(clause.type == "UnaryExpression" && clause.operator == "!") ? "logical" :
 								(["CallExpression","NewExpression",].includes(clause.type)) ? "call" :
+								(["FunctionExpression","ArrowFunctionExpression",].includes(clause.type)) ? "func" :
 								(["ArrayExpression","ObjectExpression",].includes(clause.type)) ? "object" :
 								(["Identifier","MemberExpression","Literal","TemplateLiteral",].includes(clause.type)) ? "simple" :
 								"complex";
@@ -173,6 +181,7 @@ module.exports = {
 									(comparisonMode && exprType == "comparison") ||
 									(logicalMode && exprType == "logical") ||
 									(callMode && exprType == "call") ||
+									(funcMode && exprType == "func") ||
 									(objectMode && exprType == "object") ||
 									(simpleMode && exprType == "simple") ||
 									exprType == "complex"
@@ -185,47 +194,47 @@ module.exports = {
 									fix: fixer => {
 										const fixes = [];
 
-										const isSingleLine = clause.loc.start.line === clause.loc.end.line;
+										const isSingleLine = (
+											clause.loc.start.line === clause.loc.end.line
+										);
 
 										const tokenBefore = sourceCode.getTokenBefore(clause);
 										const tokenAfter = sourceCode.getTokenAfter(clause);
 
-										if (clause.loc.start.line === tokenBefore.loc.start.line) {
-											fixes.push(
-												fixer.replaceTextRange(
-													[
-														tokenBefore.range[1],
-														clause.range[0],
-													],
-													(
-														isSingleLine
-														? '('
-														: ' (\n'
-													),
-												)
-											);
+										if (isSingleLine || extraOptions.addParensOnSameLine) {
+											fixes.push(fixer.insertTextBefore(clause, '('))
+											fixes.push(fixer.insertTextAfter(clause, ')'))
 										}
 										else {
-											fixes.push(fixer.insertTextAfter(tokenBefore, ' (\n'));
-										}
+											if (clause.loc.start.line === tokenBefore.loc.start.line) {
+												fixes.push(
+													fixer.replaceTextRange(
+														[
+															tokenBefore.range[1],
+															clause.range[0],
+														],
+														' (\n',
+													)
+												);
+											}
+											else {
+												fixes.push(fixer.insertTextAfter(tokenBefore, ' (\n'));
+											}
 
-										if (clause.loc.end.line === tokenAfter.loc.end.line) {
-											fixes.push(
-												fixer.replaceTextRange(
-													[
-														clause.range[1],
-														tokenAfter.range[0],
-													],
-													(
-														isSingleLine
-														? ')'
-														: '\n)\n'
-													),
-												)
-											);
-										}
-										else {
-											fixes.push(fixer.insertTextBefore(tokenAfter, ')\n'));
+											if (clause.loc.end.line === tokenAfter.loc.end.line) {
+												fixes.push(
+													fixer.replaceTextRange(
+														[
+															clause.range[1],
+															tokenAfter.range[0],
+														],
+														'\n)\n',
+													)
+												);
+											}
+											else {
+												fixes.push(fixer.insertTextBefore(tokenAfter, ')\n'));
+											}
 										}
 
 										return fixes;

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,8 +185,10 @@ module.exports = {
 									fix: fixer => {
 										const fixes = [];
 
-										const tokenBefore = sourceCode.getTokenBefore(clause.test)
-										const tokenAfter = sourceCode.getTokenAfter(clause.alternate)
+										const isSingleLine = clause.loc.start.line === clause.loc.end.line;
+
+										const tokenBefore = sourceCode.getTokenBefore(clause);
+										const tokenAfter = sourceCode.getTokenAfter(clause);
 
 										if (clause.loc.start.line === tokenBefore.loc.start.line) {
 											fixes.push(
@@ -195,7 +197,11 @@ module.exports = {
 														tokenBefore.range[1],
 														clause.range[0],
 													],
-													' (\n',
+													(
+														isSingleLine
+														? '('
+														: ' (\n'
+													),
 												)
 											);
 										}
@@ -210,7 +216,11 @@ module.exports = {
 														clause.range[1],
 														tokenAfter.range[0],
 													],
-													'\n)\n',
+													(
+														isSingleLine
+														? ')'
+														: '\n)\n'
+													),
 												)
 											);
 										}

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,6 +140,7 @@ module.exports = {
 				messages: {
 					needParens: "Ternary clause expression requires enclosing ( .. )",
 				},
+				fixable: "code",
 			},
 			create(context) {
 				var defaultsOnly = context.options.length == 0;
@@ -181,6 +182,44 @@ module.exports = {
 								context.report({
 									node: clause,
 									messageId: "needParens",
+									fix: fixer => {
+										const fixes = [];
+
+										const tokenBefore = sourceCode.getTokenBefore(clause.test)
+										const tokenAfter = sourceCode.getTokenAfter(clause.alternate)
+
+										if (clause.loc.start.line === tokenBefore.loc.start.line) {
+											fixes.push(
+												fixer.replaceTextRange(
+													[
+														tokenBefore.range[1],
+														clause.range[0],
+													],
+													' (\n',
+												)
+											);
+										}
+										else {
+											fixes.push(fixer.insertTextAfter(tokenBefore, ' (\n'));
+										}
+
+										if (clause.loc.end.line === tokenAfter.loc.end.line) {
+											fixes.push(
+												fixer.replaceTextRange(
+													[
+														clause.range[1],
+														tokenAfter.range[0],
+													],
+													'\n)\n',
+												)
+											);
+										}
+										else {
+											fixes.push(fixer.insertTextBefore(tokenAfter, ')\n'));
+										}
+
+										return fixes;
+									},
 								});
 							}
 						}


### PR DESCRIPTION
I added the missing `--fix` functionality.

Using `--fix` requires `indent` from ESLint for it to make sure indentation is correct after fixing.

Apparently the other newline fixes in ESLint have the same issue of requiring `indent` to properly reformat on fix.