### PR TITLE
Fix typo in where rule options schema

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -218,7 +218,7 @@ module.exports = {
 							sub: {
 								type: "boolean",
 							},
-							asssignment: {
+							assignment: {
 								type: "boolean",
 							},
 						},

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ module.exports = {
 								min: 1,
 							},
 						},
+						additionalProperties: false,
 					},
 				],
 				messages: {
@@ -135,6 +136,7 @@ module.exports = {
 								type: "boolean",
 							},
 						},
+						additionalProperties: false,
 					},
 				],
 				messages: {
@@ -222,6 +224,7 @@ module.exports = {
 								type: "boolean",
 							},
 						},
+						additionalProperties: false,
 					},
 				],
 				messages: {


### PR DESCRIPTION
The rule /where contains the typo "asssignment" in its rule options schema.
I would propose to add "additionalProperties: false" to each rule options schema, so users are warned if they mistype an option.